### PR TITLE
Fix support for Google Apps grouping under Google chrome icon

### DIFF
--- a/libtaskmanager/taskmanagerrulesrc
+++ b/libtaskmanager/taskmanagerrulesrc
@@ -1,12 +1,10 @@
 [Mapping]
 Gimp-2.8=GIMP
-Google-chrome=Google Chrome
-Google-chrome-stable=Google Chrome
 Systemsettings=System Settings
 oracle-ide-boot-Launcher=Oracle SQL Developer
 Dragon=dragonplayer
 
 [Settings]
-ManualOnly=Wine
+ManualOnly=Wine,Google-chrome-stable,Google-chrome
 MatchCommandLineFirst=perl
 TryIgnoreRuntimes=perl


### PR DESCRIPTION
I just wanted to share that I found a fix for the issue mentioned here:
https://www.reddit.com/r/kde/comments/6ftc6r/kde_510_issue_chrome_apps_combining_under_google/
and here:
https://www.reddit.com/r/kde/comments/7dwpgd/how_to_detach_the_application_icon_from_the_main/
after reading carefully the KDE code, change this
```
# /etc/xdg/taskmanagerrulesrc
[Mapping]
Gimp-2.8=GIMP
Systemsettings=System Settings
oracle-ide-boot-Launcher=Oracle SQL Developer
Dragon=dragonplayer

[Settings]
ManualOnly=Wine,Google-chrome
MatchCommandLineFirst=perl
TryIgnoreRuntimes=perl
```
basically, remove the Google-chrome parts and add it to Google-chrome (could be the process is named differently.)

If this is the case do:

`xprop | grep WM_CASS`

and click on your "Chrome App", notice the second part after the comma and that is the "name" to put under "ManualOnly".

I believe the issues were introduced at https://github.com/KDE/plasma-workspace/commit/a87f619a985c7a2f19743a70f391ebbd36a1508d#diff-02de6c36217ce1d6485a96b1f53e71da

I believe:
https://github.com/KDE/plasma-workspace/commit/a87f619a985c7a2f19743a70f391ebbd36a1508d#diff-03490ec41f424bf9c3791693166c7bd4R229
should run only after:
https://github.com/KDE/plasma-workspace/commit/a87f619a985c7a2f19743a70f391ebbd36a1508d#diff-03490ec41f424bf9c3791693166c7bd4R233

unfortunately im not so familiar with the KDE dev process, but wanted to share a potential fix.