### PR TITLE
[Run Command] Add closable property so that close button can be disabled.

### DIFF
--- a/lookandfeel/contents/runcommand/RunCommand.qml
+++ b/lookandfeel/contents/runcommand/RunCommand.qml
@@ -28,6 +28,7 @@ ColumnLayout {
     property string query
     property string runner
     property bool showHistory: false
+    property bool closable: true
 
     LayoutMirroring.enabled: Qt.application.layoutDirection === Qt.RightToLeft
     LayoutMirroring.childrenInherit: true
@@ -155,6 +156,7 @@ ColumnLayout {
             onClicked: runnerWindow.visible = false
             Accessible.name: i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Close")
             Accessible.description: i18nd("plasma_lookandfeel_org.kde.lookandfeel", "Close Search")
+            visible: root.closable
         }
     }
 


### PR DESCRIPTION
When using RunCommand.qml, e.g. as part of a plasmoid, it does not always make sense to have a close button. This adds a property that makes the element configurable in that sense. The closable property's default is 'true' which is equivalent to RunCommand's previous behavior. So this change will not break any existing software which uses RunCommand.