### PR TITLE
Fix for broken media control layout on lockscreen

### DIFF
--- a/lookandfeel/contents/lockscreen/MediaControls.qml
+++ b/lookandfeel/contents/lockscreen/MediaControls.qml
@@ -120,6 +120,7 @@ Item {
                 text: mpris2Source.track || i18nd("plasma_lookandfeel_org.kde.lookandfeel", "No media playing")
                 textFormat: Text.PlainText
                 font.pointSize: theme.defaultFont.pointSize + 1
+                maximumLineCount: 1
             }
 
             PlasmaExtras.DescriptiveLabel {
@@ -130,6 +131,7 @@ Item {
                 text: mpris2Source.artist || mpris2Source.identity || ""
                 textFormat: Text.PlainText
                 font.pointSize: theme.smallestFont.pointSize + 1
+                maximumLineCount: 1
             }
         }
 


### PR DESCRIPTION
This patch fixes the bug mentioned on Bugzilla - bug [#414487](https://bugs.kde.org/show_bug.cgi?id=414487)