### PR TITLE
Bug 392798 - Power button actions should be handled from lock screen

### DIFF
--- a/lookandfeel/contents/lockscreen/LockScreenUi.qml
+++ b/lookandfeel/contents/lockscreen/LockScreenUi.qml
@@ -38,6 +38,18 @@ PlasmaCore.ColorScope {
 
     colorGroup: PlasmaCore.Theme.ComplementaryColorGroup
 
+    function performOperation(what) {
+        var service = dataEngine.serviceForSource("PowerDevil");
+        var operation = service.operationDescription(what);
+        service.startOperationCall(operation);
+    }
+
+    PlasmaCore.DataSource {
+      id: dataEngine
+      engine: "powermanagement"
+      connectedSources: ["PowerDevil"]
+    }
+
     Connections {
         target: authenticator
         onFailed: {
@@ -125,6 +137,7 @@ PlasmaCore.ColorScope {
             }
         }
         Keys.onPressed: {
+            if (event.key == 16908292) performOperation("suspendToRam")
             uiVisible = true;
             event.accepted = false;
         }


### PR DESCRIPTION
This patch allows to use the "sleep" button on keyboards to let the computer go into suspend while still on locked sddm lockscreen
This is more consequent with the loging sddm and an active/unlocked plasma session, where the use of the sleep key works as expected.