### PR TITLE
Fix sleep/suspend sometimes not working

### DIFF
--- a/libkworkspace/sessionmanagementbackend.cpp
+++ b/libkworkspace/sessionmanagementbackend.cpp
@@ -137,7 +137,6 @@ void LogindSessionBackend::shutdown()
 {
     // logind will confirm credentials with the caller, if the app quits after sending this
     // this may fail
-    // its not really needed for suspend tasks where the calling app won't be closing
     m_login1->PowerOff(true).waitForFinished();
 }
 
@@ -148,17 +147,19 @@ void LogindSessionBackend::reboot()
 
 void LogindSessionBackend::suspend()
 {
-    m_login1->Suspend(true);
+    // these need to be synchronous as well - ksmserver-logout-greeter specifically calls these
+    // and will quit immediately after
+    m_login1->Suspend(true).waitForFinished();
 }
 
 void LogindSessionBackend::hybridSuspend()
 {
-    m_login1->HybridSleep(true);
+    m_login1->HybridSleep(true).waitForFinished();
 }
 
 void LogindSessionBackend::hibernate()
 {
-    m_login1->Hibernate(true);
+    m_login1->Hibernate(true).waitForFinished();;
 }
 
 bool LogindSessionBackend::canShutdown() const


### PR DESCRIPTION
... from ksmserver-logout-greeter, by making the DBus calls synchronous.

As is already noted for the shutdown and reboot cases, systemd-logind will check the calling process for credentials. This fails when the calling process has already exited.

In the case of requesting sleep/suspend/hibernate, this very thing happens specifically from ksmserver-logout-greeter - the (optional?) choices screen shown for a logout/sleep/power action.

See also the bug report where this all started out: https://bugs.gentoo.org/818124