### PR TITLE
Show more than just 5 events in list

### DIFF
--- a/components/calendar/daysmodel.cpp
+++ b/components/calendar/daysmodel.cpp
@@ -14,7 +14,7 @@
 #include <QDir>
 #include <QMetaObject>
 
-constexpr int maxEventDisplayed = 5;
+constexpr int maxEventDisplayed = 20;
 
 class DaysModelPrivate
 {


### PR DESCRIPTION
Fixing https://bugs.kde.org/show_bug.cgi?id=468458 "Events are capped at 5 per day and show a random assortment when the day has more than 5 events" by increasing the number to 20. 
I found this patch in the bug discussion at https://bugs.kde.org/show_bug.cgi?id=468458