### PR TITLE
applets/digital-clock: create a color picker

### DIFF
--- a/applets/digital-clock/package/contents/config/main.xml
+++ b/applets/digital-clock/package/contents/config/main.xml
@@ -59,6 +59,10 @@
       <label>Sets font size.</label>
       <default>10</default>
     </entry>
+    <entry name="color" type="string">
+      <label>Sets text color</label>
+      <default>#111111</default>
+    </entry>
     <entry name="timeFormat" type="string">
       <default>default</default>
     </entry>

--- a/applets/digital-clock/package/contents/ui/DigitalClock.qml
+++ b/applets/digital-clock/package/contents/ui/DigitalClock.qml
@@ -541,6 +541,7 @@ MouseArea {
                     features: { "tnum": 1 }
                     pixelSize: 1024
                 }
+                color: Plasmoid.configuration.color
                 minimumPixelSize: 1
 
                 text: Qt.formatTime(main.getCurrentTime(), Plasmoid.configuration.showSeconds === 2 ? main.timeFormatWithSeconds : main.timeFormat)
@@ -556,6 +557,7 @@ MouseArea {
                 font.weight: timeLabel.font.weight
                 font.italic: timeLabel.font.italic
                 font.pixelSize: 1024
+                color: timeLabel.color
                 minimumPixelSize: 1
 
                 visible: text.length > 0
@@ -573,7 +575,7 @@ MouseArea {
             height: timeLabel.height * 0.8
             width: timeLabel.height / 16
             radius: width / 2
-            color: Kirigami.Theme.textColor
+            color: timeLabel.color
 
             anchors.leftMargin: timeMetrics.advanceWidth(" ") + width / 2
             anchors.verticalCenter: parent.verticalCenter
@@ -591,6 +593,7 @@ MouseArea {
             font.weight: timeLabel.font.weight
             font.italic: timeLabel.font.italic
             font.pixelSize: 1024
+            color: timeLabel.color
             minimumPixelSize: 1
 
             horizontalAlignment: Text.AlignHCenter

--- a/applets/digital-clock/package/contents/ui/configAppearance.qml
+++ b/applets/digital-clock/package/contents/ui/configAppearance.qml
@@ -34,6 +34,8 @@ KCMUtils.SimpleKCM {
     property alias cfg_fontStyleName: fontDialog.fontChosen.styleName
     property alias cfg_fontSize: fontDialog.fontChosen.pointSize
 
+    property alias cfg_color: colorDialog.colorChosen
+
     property string cfg_timeFormat: ""
     property alias cfg_showLocalTimezone: showLocalTimeZone.checked
     property alias cfg_displayTimezoneFormat: displayTimeZoneFormat.currentIndex
@@ -256,6 +258,7 @@ KCMUtils.SimpleKCM {
                 onClicked: {
                     if (cfg_fontFamily === "") {
                         fontDialog.fontChosen = Kirigami.Theme.defaultFont
+                        colorDialog.colorChosen = Kirigami.Theme.textColor
                     }
                 }
             }
@@ -269,6 +272,15 @@ KCMUtils.SimpleKCM {
                     fontDialog.open()
                 }
             }
+            QQC2.Button {
+                    text: i18nc("@action:button", "Choose Color…")
+                    icon.name: "preferences-desktop-color"
+                    enabled: manualFontAndSizeRadioButton.checked
+                    onClicked: {
+                        colorDialog.selectedColor = colorDialog.colorChosen
+                        colorDialog.open()
+                    }
+                }
 
         }
 
@@ -277,12 +289,14 @@ KCMUtils.SimpleKCM {
             text: i18nc("@info %1 is the font size, %2 is the font family", "%1pt %2", cfg_fontSize, fontDialog.fontChosen.family)
             textFormat: Text.PlainText
             font: fontDialog.fontChosen
+            color: colorDialog.colorChosen
         }
         QQC2.Label {
             visible: manualFontAndSizeRadioButton.checked
             text: i18nc("@info", "Note: size may be reduced if the panel is not thick enough.")
             textFormat: Text.PlainText
             font: Kirigami.Theme.smallFont
+            color: colorDialog.colorChosen
         }
     }
 
@@ -296,6 +310,19 @@ KCMUtils.SimpleKCM {
 
         onAccepted: {
             fontChosen = selectedFont
+        }
+    }
+
+    QtDialogs.ColorDialog {
+        id: colorDialog
+        title: i18nc("@title:window", "Choose a Color")
+        modality: Qt.WindowModal
+        parentWindow: appearancePage.Window.window
+
+        property color colorChosen: Qt.currentColor()
+
+        onAccepted: {
+            colorChosen = selectedColor
         }
     }
 


### PR DESCRIPTION
there is currently no way to select a custom color for the digital clock. There a currently workarounds but a default solution would be better https://discuss.kde.org/t/custom-color-date-format-in-the-digitalclock-plasmoid-in-plasma-6-1/24296