### PR TITLE
fix(systemtray): guard SNI source during token requests

### DIFF
--- a/applets/systemtray/systemtray.cpp
+++ b/applets/systemtray/systemtray.cpp
@@ -21,6 +21,7 @@
 #include <QMenu>
 #include <QMetaMethod>
 #include <QMetaObject>
+#include <QPointer>
 #include <QQueue>
 #include <QQuickItem>
 #include <QQuickWindow>
@@ -576,10 +577,15 @@ void SystemTray::activate(const QString &service, QPoint pos, QQuickItem *status
         return;
     }
 
+    const QPointer<StatusNotifierItemSource> sourceGuard(source);
     auto tokenFuture = KWaylandExtras::xdgActivationToken(window, {});
-    tokenFuture.then(source, [source, service, pos](const QString &token) {
-        source->provideXdgActivationToken(token);
-        source->activate(pos.x(), pos.y());
+    tokenFuture.then(this, [sourceGuard, service, pos](const QString &token) {
+        if (!sourceGuard) {
+            qCWarning(SYSTEM_TRAY) << "activate: Item disappeared before xdg activation token was received" << service;
+            return;
+        }
+        sourceGuard->provideXdgActivationToken(token);
+        sourceGuard->activate(pos.x(), pos.y());
     });
 }
 
@@ -598,10 +604,15 @@ void SystemTray::secondaryActivate(const QString &service, QPoint pos)
         return;
     }
 
+    const QPointer<StatusNotifierItemSource> sourceGuard(source);
     auto tokenFuture = KWaylandExtras::xdgActivationToken(window, {});
-    tokenFuture.then(source, [source, pos](const QString &token) {
-        source->provideXdgActivationToken(token);
-        source->secondaryActivate(pos.x(), pos.y());
+    tokenFuture.then(this, [sourceGuard, service, pos](const QString &token) {
+        if (!sourceGuard) {
+            qCWarning(SYSTEM_TRAY) << "secondaryActivate: Item disappeared before xdg activation token was received" << service;
+            return;
+        }
+        sourceGuard->provideXdgActivationToken(token);
+        sourceGuard->secondaryActivate(pos.x(), pos.y());
     });
 }
 
@@ -642,10 +653,15 @@ void SystemTray::openContextMenu(const QString &service, QPoint pos, QQuickItem 
         return;
     }
 
+    const QPointer<StatusNotifierItemSource> sourceGuard(source);
     auto tokenFuture = KWaylandExtras::xdgActivationToken(window, {});
-    tokenFuture.then(source, [source, pos](const QString &token) {
-        source->provideXdgActivationToken(token);
-        source->contextMenu(pos.x(), pos.y());
+    tokenFuture.then(this, [sourceGuard, service, pos](const QString &token) {
+        if (!sourceGuard) {
+            qCWarning(SYSTEM_TRAY) << "openContextMenu: Item disappeared before xdg activation token was received" << service;
+            return;
+        }
+        sourceGuard->provideXdgActivationToken(token);
+        sourceGuard->contextMenu(pos.x(), pos.y());
     });
 }
 


### PR DESCRIPTION
## Summary

Guard asynchronous Wayland xdg activation token continuations with QPointer<StatusNotifierItemSource>.
- Use SystemTray as the QFuture continuation context so a disappearing StatusNotifierItemSource is not dereferenced by QFuture::then().
- Abort activation/context menu requests cleanly if the tray item disappears before the token is delivered.

## Evidence
Observed a plasmashell crash on Fedora 43 / Plasma 6.6.3 Wayland while opening a system tray context menu. The coredump points at SystemTray::openContextMenu() through QFutureInterfaceBase::setContinuation() / QObject::thread(), consistent with an invalid SNI source/context around the asynchronous xdg activation token request.

Backtrace excerpt:

    #4 QObject::thread() const
    #5 QFutureInterfaceBase::setContinuation(...)
    #6 SystemTray::openContextMenu(QString const&, QPoint, QQuickItem*)

## Test plan
- git diff --check
- Local full compile was not completed in this session because the interactive build command was denied by the environment after installing Fedora build dependencies.
